### PR TITLE
Add Extension page

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,10 @@ module.exports = {
         // See https://github.com/sveltejs/eslint-plugin-svelte3/issues/104
         "@typescript-eslint/no-unsafe-member-access": "off",
       },
+      env: {
+        browser: true,
+        webextensions: true,
+      },
     },
   ],
   rules: {},

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -24,7 +24,7 @@
     </div>
   {/if}
   <p>Worker status: {workerState?.status.type}</p>
-  <button on:click={scanAllegro}>Scan Allegro</button>
+  <button on:click={() => scanAllegro(isExtensionPage)}>Scan Allegro</button>
 
   {#if workerState?.offers}
     <ul>
@@ -34,7 +34,7 @@
           <!-- Unsafe mutation of the offers array. TODO: use local state for the input -->
 
           <input bind:value={offer.price} />
-          <button on:click={() => changePrice(offer, offer.price)}
+          <button on:click={() => changePrice(offer, offer.price, isExtensionPage)}
             >Change price</button
           >
         </li>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,6 +4,8 @@
   import type { WorkerState } from "./worker";
 
   let workerState: WorkerState | null = null;
+  const isExtensionPage = window.location.search.includes("fullpage");
+  const extensionPageUrl = chrome.runtime.getURL("index.html?fullpage");
 
   onMount(() => {
     connect((state) => {
@@ -14,6 +16,13 @@
 
 <div class="App">
   <button on:click={reloadExtension}>Reload extension</button>
+  {#if !isExtensionPage}
+    <div>
+      <a href={extensionPageUrl} target="_blank" rel="noreferrer noopener"
+        >Open extension page</a
+      >
+    </div>
+  {/if}
   <p>Worker status: {workerState?.status.type}</p>
   <button on:click={scanAllegro}>Scan Allegro</button>
 
@@ -25,7 +34,9 @@
           <!-- Unsafe mutation of the offers array. TODO: use local state for the input -->
 
           <input bind:value={offer.price} />
-          <button on:click={() => changePrice(offer, offer.price)}>Change price</button>
+          <button on:click={() => changePrice(offer, offer.price)}
+            >Change price</button
+          >
         </li>
       {/each}
     </ul>

--- a/src/marketplaces/allegro/workflows/change-price.ts
+++ b/src/marketplaces/allegro/workflows/change-price.ts
@@ -13,13 +13,15 @@ import {
 export interface ChangePriceWorkflowParams {
   offerEditUrl: string;
   newPrice: string;
+  focusNewTab: boolean;
 }
 
 export async function changePriceWorkflow({
   newPrice,
   offerEditUrl,
+  focusNewTab,
 }: ChangePriceWorkflowParams): Promise<void> {
-  const tab = await createTab({ active: false });
+  const tab = await createTab({ active: focusNewTab });
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const tabId = tab.id!;
 

--- a/src/marketplaces/allegro/workflows/get-offers.ts
+++ b/src/marketplaces/allegro/workflows/get-offers.ts
@@ -12,8 +12,10 @@ import {
 
 const offersPageUrl = "https://allegrolokalnie.pl/konto/oferty/aktywne";
 
-export async function getOffersWorkflow(): Promise<Offer[]> {
-  const tab = await createTab({ active: false });
+export async function getOffersWorkflow(
+  focusNewTab: boolean
+): Promise<Offer[]> {
+  const tab = await createTab({ active: focusNewTab });
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const tabId = tab.id!;
 

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -33,7 +33,9 @@ export function connect(
   });
 }
 
-export function scanAllegro(): Promise<Offer[]> | undefined {
+export function scanAllegro(
+  focusNewTab: boolean
+): Promise<Offer[]> | undefined {
   const port = chrome.runtime.connect();
   if (chrome.runtime.lastError) {
     console.error(
@@ -55,14 +57,15 @@ export function scanAllegro(): Promise<Offer[]> | undefined {
 
     return message.data;
   });
-  port.postMessage(getOffersDriverCommand.request.create());
+  port.postMessage(getOffersDriverCommand.request.create({ focusNewTab }));
 
   return response;
 }
 
 export function changePrice(
   offer: Offer,
-  newPrice: string
+  newPrice: string,
+  focusNewTab: boolean
 ): Promise<void> | undefined {
   const port = chrome.runtime.connect();
   if (chrome.runtime.lastError) {
@@ -89,6 +92,7 @@ export function changePrice(
     changePriceDriverCommand.request.create({
       newPrice,
       offerEditUrl: offer.editUrl,
+      focusNewTab,
     })
   );
 

--- a/src/worker/driver-commands/change-price.ts
+++ b/src/worker/driver-commands/change-price.ts
@@ -2,5 +2,5 @@ import { createAppRequestResponsePair } from "@app/messaging";
 
 export const changePriceDriverCommand = createAppRequestResponsePair<
   "DRIVER/CHANGE_PRICE",
-  { newPrice: string; offerEditUrl: string }
+  { newPrice: string; offerEditUrl: string, focusNewTab: boolean }
 >("DRIVER/CHANGE_PRICE");

--- a/src/worker/driver-commands/get-offers.ts
+++ b/src/worker/driver-commands/get-offers.ts
@@ -3,6 +3,6 @@ import { createAppRequestResponsePair } from "@app/messaging";
 
 export const getOffersDriverCommand = createAppRequestResponsePair<
   "DRIVER/GET_OFFERS",
-  void,
+  { focusNewTab: boolean },
   Offer[]
 >("DRIVER/GET_OFFERS");

--- a/src/worker/service-worker.ts
+++ b/src/worker/service-worker.ts
@@ -34,9 +34,9 @@ function updateWorkerState(stateUpdate: Partial<WorkerState>) {
 }
 
 const respond = combineResponders(
-  createResponder(getOffersDriverCommand, async () => {
+  createResponder(getOffersDriverCommand, async ({ data: { focusNewTab } }) => {
     updateWorkerState({ status: { type: "working" } });
-    const offers = await getOffersWorkflow();
+    const offers = await getOffersWorkflow(focusNewTab);
     chrome.storage.local.set({ offers });
 
     updateWorkerState({ status: { type: "idle" }, offers });
@@ -44,10 +44,10 @@ const respond = combineResponders(
   }),
   createResponder(
     changePriceDriverCommand,
-    async ({ data: { newPrice, offerEditUrl } }) => {
+    async ({ data: { newPrice, offerEditUrl, focusNewTab } }) => {
       console.log("got change price command");
       updateWorkerState({ status: { type: "working" } });
-      await changePriceWorkflow({ newPrice, offerEditUrl });
+      await changePriceWorkflow({ newPrice, offerEditUrl, focusNewTab });
       updateWorkerState({ status: { type: "idle" } });
     }
   )


### PR DESCRIPTION
Add a basic extension page that allows viewing the same view as the popup but using more screen estate.

When running actions from the extension page, the created tabs are automatically focused. This makes it easier to see what the extension is doing